### PR TITLE
Fix session lifecycle, RSVP notify, and sync clobber bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,12 @@ Google is the one provider that needs real setup: Google requires every app to b
 
 1. Create a project at [console.cloud.google.com](https://console.cloud.google.com) and enable the **Google Calendar API** for it.
 2. Under **Google Auth Platform → Audience**, set the app to External, and add your own Google account under **Test users** (the app stays unverified/"Testing," which is fine for personal use — publishing for public verification is a separate, much heavier process not needed here).
-3. Under **Data Access**, add the `.../auth/calendar` scope.
+3. Under **Data Access**, add these scopes:
+   - `https://www.googleapis.com/auth/calendar.events`
+   - `https://www.googleapis.com/auth/calendar.calendarlist.readonly`
+
+   Calix requests exactly those two at sign-in; the broader `.../auth/calendar`
+   scope is not used.
 4. Under **Clients**, create an OAuth client of type **Desktop app**. Copy the Client ID and Client Secret.
 5. In Calix, choose **Connect an account → Google Calendar**, paste the Client
    ID and Client Secret, then choose **Save and sign in**. Calix writes them to
@@ -239,7 +244,7 @@ The calendar button in the header toggles the sidebar, which opens with a mini m
 - **Drag out a new event**: in week/day view, press on empty grid space and drag to draw the event's span, with a live preview snapped to 15 minutes. The dialog opens pre-filled with exactly the range you drew instead of the default hour. Dragging upward works the same as downward, and the span stops at midnight rather than spilling into the next day.
 - **Pick a calendar**: the new-event dialog's calendar dropdown lists only the calendars currently visible in the sidebar; **Show all calendars…** at the bottom expands it to everything. Hiding noisy subscribed calendars once keeps the picker short.
 - **Move and resize**: in week/day view, drag an event's body to move it, or its top/bottom edge to resize, with a live preview snapped to 15 minutes; dragging against the top or bottom of the grid auto-scrolls to off-screen hours. In month view, drag a chip to another day. Changes to synced events are pushed back to their source (Google/iCloud/CalDAV), and roll back if the remote update fails.
-- **Inspect and RSVP**: click any event for a popover with its time, calendar, location, notes, and attendee replies. Invitations identified as yours offer **Accept**, **Maybe**, and **Decline** without leaving Calix. **Edit** opens the full dialog.
+- **Inspect and RSVP**: click any event for a popover with its time, calendar, location, notes, and attendee replies. Invitations identified as yours offer **Accept**, **Maybe**, and **Decline** without leaving Calix. Google notifies the organizer of the reply. CalDAV writes the new status onto the event on the server; whether that notifies the organizer depends on the server (many, including iCloud, keep it as a local PARTSTAT change). **Edit** opens the full dialog.
 - **Invite**: add comma-separated email addresses while creating an event on Google Calendar. Google delivers updates to invitees; attendee lists remain read-only afterward so ordinary event edits cannot accidentally rewrite the guest list.
 - **Search**: the magnifier in the header (`Ctrl+F`) matches event titles, locations, and notes across every visible calendar. Picking a result jumps the grid to that day. Results are capped, and the popover says so when the cap bites rather than passing a truncated list off as the whole answer.
 - **Alerts**: pick an alert in the event dialog ("At time of event" up to "1 day before") to get a desktop notification. Alerts are local to this machine and continue after the window is closed. In **Calendars → Manage**, enable **Start Calix when you sign in** to make them reliable across login sessions.

--- a/src/caldav.rs
+++ b/src/caldav.rs
@@ -308,6 +308,14 @@ pub fn respond_to_event(
     attendee_email: &str,
     response: &str,
 ) -> Result<(), String> {
+    // CalDAV has no equivalent of Google's `sendUpdates=all`. This writes the
+    // new PARTSTAT onto the attendee's copy of the resource and PUTs it back.
+    // Servers that honour scheduling (scheduling outbox / iTIP METHOD:REPLY)
+    // may then notify the organizer; iCloud, Fastmail, and many personal
+    // servers treat the PUT as a local status change only. Calix does not
+    // POST an iTIP REPLY: that needs an organizer address, a scheduling
+    // inbox/outbox pair, and per-server support we cannot assume. The popover
+    // still records the reply locally and on any server that stores PARTSTAT.
     let resource_href = event_href
         .split_once('#')
         .map_or(event_href, |(href, _)| href);
@@ -828,12 +836,26 @@ fn xml_unescape(s: &str) -> String {
 fn parse_resource(href: &str, ics: &str) -> (Vec<RemoteEvent>, bool) {
     let components = ics_event_properties(ics);
     let total = components.len();
-    let events = components
-        .into_iter()
-        .filter_map(|component| parse_event(href, component, total))
-        .collect::<Vec<_>>();
-    let complete = events.len() == total;
+    let mut skipped_cancelled = 0usize;
+    let mut events = Vec::new();
+    for component in components {
+        if ics_status_is_cancelled(&component) {
+            skipped_cancelled += 1;
+            continue;
+        }
+        if let Some(event) = parse_event(href, component, total) {
+            events.push(event);
+        }
+    }
+    let complete = events.len() + skipped_cancelled == total;
     (events, complete)
+}
+
+fn ics_status_is_cancelled(component: &IcsEvent) -> bool {
+    component
+        .props
+        .get("STATUS")
+        .is_some_and(|property| property.value.eq_ignore_ascii_case("CANCELLED"))
 }
 
 fn parse_event(href: &str, component: IcsEvent, component_count: usize) -> Option<RemoteEvent> {
@@ -1853,6 +1875,50 @@ END:VEVENT\r\nEND:VCALENDAR\r\n";
         assert_eq!(attendees[1].email, "bob@example.com");
         assert_eq!(attendees[1].name, None);
         assert_eq!(attendees[1].status.as_deref(), Some("pending"));
+    }
+
+    #[test]
+    fn a_lowercase_cancelled_status_is_still_dropped() {
+        let ics = "BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nUID:gone\r\nSUMMARY:Cancelled\r\n\
+DTSTART:20260709T140000Z\r\nDTEND:20260709T143000Z\r\nSTATUS:cancelled\r\n\
+END:VEVENT\r\nEND:VCALENDAR\r\n";
+        let (events, complete) = parse_resource("/calendars/work/gone.ics", ics);
+        assert!(events.is_empty());
+        assert!(complete);
+    }
+
+    #[test]
+    fn cancelled_vevents_are_dropped_rather_than_shown() {
+        let ics = "BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nUID:gone\r\nSUMMARY:Cancelled\r\n\
+DTSTART:20260709T140000Z\r\nDTEND:20260709T143000Z\r\nSTATUS:CANCELLED\r\n\
+END:VEVENT\r\nEND:VCALENDAR\r\n";
+        let (events, complete) = parse_resource("/calendars/work/gone.ics", ics);
+        assert!(events.is_empty());
+        assert!(
+            complete,
+            "a cancelled VEVENT is a successful skip, not an unreadable resource"
+        );
+    }
+
+    #[test]
+    fn a_cancelled_instance_does_not_protect_the_resource_from_prune() {
+        let ics = "BEGIN:VCALENDAR\r\n\
+BEGIN:VEVENT\r\nSUMMARY:Keep\r\nDTSTART:20260709T140000Z\r\nDTEND:20260709T143000Z\r\n\
+RECURRENCE-ID:20260709T140000Z\r\nEND:VEVENT\r\n\
+BEGIN:VEVENT\r\nSUMMARY:Gone\r\nDTSTART:20260716T140000Z\r\nDTEND:20260716T143000Z\r\n\
+RECURRENCE-ID:20260716T140000Z\r\nSTATUS:CANCELLED\r\nEND:VEVENT\r\n\
+END:VCALENDAR\r\n";
+        let xml = format!(
+            "<D:multistatus xmlns:D=\"DAV:\" xmlns:C=\"urn:ietf:params:xml:ns:caldav\">\
+             <D:response><D:href>/calendars/work/series.ics</D:href><D:propstat><D:prop>\
+             <C:calendar-data>{}</C:calendar-data>\
+             </D:prop></D:propstat></D:response></D:multistatus>",
+            ics.replace('&', "&amp;").replace('<', "&lt;")
+        );
+        let synced = reconcile_calendar_query(&xml);
+        assert_eq!(synced.events.len(), 1);
+        assert!(synced.unreadable.is_empty());
+        assert!(synced.prunable);
     }
 
     #[test]

--- a/src/calendar_dialog.rs
+++ b/src/calendar_dialog.rs
@@ -204,12 +204,39 @@ fn calendar_row(
         #[strong]
         on_changed,
         move |_, state| {
-            if store.set_calendar_visible(calendar_id, state).is_ok() {
+            let write_ok = store.set_calendar_visible(calendar_id, state).is_ok();
+            if write_ok {
                 on_changed();
             }
-            glib::Propagation::Proceed
+            visibility_toggle_applies(write_ok)
         }
     ));
 
     row
+}
+
+/// GTK applies a Switch's new state unless `state-set` stops emission. A
+/// failed store write must stop, so the switch stays on the value SQLite
+/// still has rather than looking flipped while the grid disagrees.
+fn visibility_toggle_applies(write_succeeded: bool) -> glib::Propagation {
+    if write_succeeded {
+        glib::Propagation::Proceed
+    } else {
+        glib::Propagation::Stop
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_successful_visibility_write_lets_gtk_apply_the_new_state() {
+        assert_eq!(visibility_toggle_applies(true), glib::Propagation::Proceed);
+    }
+
+    #[test]
+    fn a_failed_visibility_write_keeps_the_switch_on_the_stored_value() {
+        assert_eq!(visibility_toggle_applies(false), glib::Propagation::Stop);
+    }
 }

--- a/src/google/calendar_api.rs
+++ b/src/google/calendar_api.rs
@@ -76,6 +76,11 @@ pub struct EventItem {
     pub attendees: Vec<EventAttendee>,
     pub start: EventDateTime,
     pub end: EventDateTime,
+    /// Present on expanded instances (`singleEvents=true`); names the series
+    /// the occurrence belongs to so a local reminder on the master can be
+    /// copied onto the new row.
+    #[serde(default, rename = "recurringEventId")]
+    pub recurring_event_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -302,7 +307,7 @@ pub fn respond_to_event(
         return Err("Google did not identify your invitation on this event".to_string());
     };
     me.status = Some(response.to_string());
-    let url = event_url(calendar_id, event_id)?;
+    let url = event_url_notifying(calendar_id, event_id)?;
     let body = serde_json::json!({
         "attendees": attendees.iter().map(|attendee| serde_json::json!({
             "email": attendee.email,
@@ -377,6 +382,12 @@ fn event_url(calendar_id: &str, event_id: &str) -> Result<Url, String> {
         .push(calendar_id)
         .push("events")
         .push(event_id);
+    Ok(url)
+}
+
+fn event_url_notifying(calendar_id: &str, event_id: &str) -> Result<Url, String> {
+    let mut url = event_url(calendar_id, event_id)?;
+    url.query_pairs_mut().append_pair("sendUpdates", "all");
     Ok(url)
 }
 
@@ -562,6 +573,7 @@ mod tests {
                 date_time: None,
                 time_zone: None,
             },
+            recurring_event_id: None,
         };
 
         assert!(!event.is_displayable_calendar_event());
@@ -588,6 +600,7 @@ mod tests {
             },
             conference_data: None,
             attendees: Vec::new(),
+            recurring_event_id: None,
         };
 
         assert!(event.is_displayable_calendar_event());
@@ -652,6 +665,16 @@ mod tests {
         assert_eq!(
             local.with_timezone(&chrono::Utc),
             chrono::Utc.with_ymd_and_hms(2026, 7, 9, 13, 0, 0).unwrap()
+        );
+    }
+
+    #[test]
+    fn an_rsvp_url_asks_google_to_notify_everyone() {
+        let url = event_url_notifying("primary", "evt-1").unwrap();
+        assert!(
+            url.query_pairs()
+                .any(|(key, value)| key == "sendUpdates" && value == "all"),
+            "RSVP must send sendUpdates=all so the organizer is notified: {url}"
         );
     }
 }

--- a/src/google/sync.rs
+++ b/src/google/sync.rs
@@ -82,9 +82,10 @@ pub fn sync_account(
         }
         for pending in &reconciliation.upserts {
             store
-                .upsert_google_event(
+                .upsert_google_event_from_series(
                     local_calendar_id,
                     pending.event_id,
+                    pending.series_id.as_deref(),
                     &pending.draft,
                     &pending.attendees,
                 )
@@ -104,23 +105,24 @@ pub fn sync_account(
     Ok(outcome)
 }
 
+/// One event ready to write: its Google id, the draft, and the invitee list.
+/// Attendees ride alongside the draft rather than inside it, so the local edit
+/// path (which builds drafts by hand) cannot blank them.
+struct PendingUpsert<'a> {
+    event_id: &'a str,
+    series_id: Option<String>,
+    draft: EventDraft,
+    attendees: Vec<Attendee>,
+}
+
 struct Reconciliation<'a> {
     upserts: Vec<PendingUpsert<'a>>,
     keep_ids: Vec<String>,
     skipped: Vec<&'a str>,
 }
 
-/// One event ready to write: its Google id, the draft, and the invitee list.
-/// Attendees ride alongside the draft rather than inside it, so the local edit
-/// path (which builds drafts by hand) can't blank them.
-struct PendingUpsert<'a> {
-    event_id: &'a str,
-    draft: EventDraft,
-    attendees: Vec<Attendee>,
-}
-
 /// Splits fetched events into the drafts to upsert and the full set of ids to
-/// keep. Every returned event's id is kept — even one we can't turn into a
+/// keep. Every returned event's id is kept — even one we cannot turn into a
 /// draft — so a transient parse failure never lets pruning delete an event that
 /// Google still returned.
 fn reconcile_events(events: &[calendar_api::EventItem]) -> Reconciliation<'_> {
@@ -132,6 +134,7 @@ fn reconcile_events(events: &[calendar_api::EventItem]) -> Reconciliation<'_> {
         match event_draft(event) {
             Some(draft) => upserts.push(PendingUpsert {
                 event_id: event.id.as_str(),
+                series_id: event.recurring_event_id.clone(),
                 draft,
                 attendees: event.invitees(),
             }),
@@ -227,7 +230,25 @@ mod tests {
             attendees: Vec::new(),
             start,
             end,
+            recurring_event_id: None,
         }
+    }
+
+    #[test]
+    fn reconcile_passes_the_series_id_of_an_expanded_instance() {
+        let mut item = event(
+            "occ-1",
+            timed("2026-01-17T09:00:00Z"),
+            timed("2026-01-17T10:00:00Z"),
+        );
+        item.recurring_event_id = Some("series-1".to_string());
+        let events = [item];
+        let reconciliation = reconcile_events(&events);
+        assert_eq!(reconciliation.upserts.len(), 1);
+        assert_eq!(
+            reconciliation.upserts[0].series_id.as_deref(),
+            Some("series-1")
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,12 +129,31 @@ pub fn run() -> gtk::glib::ExitCode {
         let background = autostart::is_background_launch(&args);
         // The invoking process rejects a bad date before it forwards, so one
         // can't arrive here; opening on today beats refusing to open at all.
-        if background && app.active_window().is_none() {
-            window::start_background(app);
-        } else {
+        // Do not key this off `active_window()`: hide-on-close leaves the
+        // window present but not active, and a second `--background` must
+        // reuse that Ui rather than present it (or build another).
+        if command_line_presents_window(background) {
             window::open(app, date_util::parse_date_arg(&args).unwrap_or(None));
+        } else {
+            window::start_background(app);
         }
         glib::ExitCode::SUCCESS
     });
     app.run()
+}
+
+/// A `--background` command line attaches to the running process without
+/// presenting a window. Any other command line opens or re-presents the UI.
+#[cfg(feature = "gui")]
+fn command_line_presents_window(background_launch: bool) -> bool {
+    !background_launch
+}
+
+#[cfg(all(test, feature = "gui"))]
+mod tests {
+    #[test]
+    fn a_background_command_line_does_not_present_a_window() {
+        assert!(!super::command_line_presents_window(true));
+        assert!(super::command_line_presents_window(false));
+    }
 }

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -4,7 +4,16 @@
 //! `gio::Notification`) lives in `window.rs`.
 
 use crate::store::Event;
-use chrono::{DateTime, Local};
+use chrono::{DateTime, Duration, Local};
+
+/// Setting key for the last wall-clock instant an alert sweep completed.
+/// Persisted so a login launch can catch alerts that came due while Calix
+/// was not running, without firing an unbounded backlog.
+pub const CHECKPOINT_SETTING_KEY: &str = "last_alert_check";
+
+/// Longest picker lead time is one day; looking back a little further still
+/// catches this morning's alerts after a late login, but not last week's.
+pub const CATCH_UP_LOOKBACK: Duration = Duration::hours(36);
 
 /// The reminder choices offered by the event dialog, in picker order: the
 /// label shown in the row and the alert's lead time in minutes before the
@@ -50,6 +59,29 @@ pub fn due_alerts(events: &[Event], after: DateTime<Local>, up_to: DateTime<Loca
         })
         .cloned()
         .collect()
+}
+
+/// The start of the half-open tick window `(after, now]`.
+///
+/// A stored checkpoint inside the lookback is used as-is, so adjacent ticks
+/// stay contiguous. A missing or ancient checkpoint is clamped to
+/// [`CATCH_UP_LOOKBACK`] before `now`, so a first launch or a long gap cannot
+/// dump every historical reminder. A checkpoint in the future (clock jumped
+/// backwards) collapses to `now`, producing an empty window rather than
+/// re-firing.
+pub fn alert_window(stored: Option<DateTime<Local>>, now: DateTime<Local>) -> DateTime<Local> {
+    let floor = now - CATCH_UP_LOOKBACK;
+    stored.unwrap_or(floor).clamp(floor, now)
+}
+
+/// The checkpoint to persist after a sweep. A failed query must keep the
+/// previous value so that window is retried instead of skipped forever.
+pub fn next_checkpoint(
+    query_succeeded: bool,
+    previous: DateTime<Local>,
+    now: DateTime<Local>,
+) -> DateTime<Local> {
+    if query_succeeded { now } else { previous }
 }
 
 /// Body text for an event alert, e.g. "Today at 9:05 AM — Suite 210" or
@@ -195,6 +227,41 @@ mod tests {
         event.all_day = true;
         let body = notification_body(&event, at(2026, 7, 20, 0, 0));
         assert_eq!(body, "Tomorrow, all day");
+    }
+
+    #[test]
+    fn a_recent_checkpoint_is_used_as_the_window_start() {
+        let now = at(2026, 8, 21, 9, 0);
+        let stored = at(2026, 8, 21, 8, 59);
+        assert_eq!(alert_window(Some(stored), now), stored);
+    }
+
+    #[test]
+    fn a_missing_checkpoint_looks_back_only_a_bounded_window() {
+        let now = at(2026, 8, 21, 9, 0);
+        assert_eq!(alert_window(None, now), now - CATCH_UP_LOOKBACK);
+    }
+
+    #[test]
+    fn an_ancient_checkpoint_is_clamped_to_the_lookback() {
+        let now = at(2026, 8, 21, 9, 0);
+        let stored = at(2026, 7, 1, 9, 0);
+        assert_eq!(alert_window(Some(stored), now), now - CATCH_UP_LOOKBACK);
+    }
+
+    #[test]
+    fn a_checkpoint_in_the_future_collapses_to_an_empty_window() {
+        let now = at(2026, 8, 21, 9, 0);
+        let stored = at(2026, 8, 21, 10, 0);
+        assert_eq!(alert_window(Some(stored), now), now);
+    }
+
+    #[test]
+    fn a_failed_query_does_not_advance_the_checkpoint() {
+        let previous = at(2026, 8, 21, 8, 0);
+        let now = at(2026, 8, 21, 9, 0);
+        assert_eq!(next_checkpoint(false, previous, now), previous);
+        assert_eq!(next_checkpoint(true, previous, now), now);
     }
 
     #[test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -248,6 +248,10 @@ impl Store {
         // JSON array of `Attendee`, written only by sync. `update_event` never
         // touches it, so editing an event locally keeps the provider's list.
         ensure_column(&conn, "events", "attendees", "TEXT")?;
+        // Set by a local create/edit that has not yet been confirmed by a
+        // successful remote write. Sync upserts and prunes skip these rows so
+        // an in-flight drag cannot be overwritten by a concurrent pull.
+        ensure_column(&conn, "events", "local_edit", "INTEGER NOT NULL DEFAULT 0")?;
 
         conn.execute_batch(
             "
@@ -325,6 +329,23 @@ impl Store {
             params![key, value],
         )?;
         Ok(())
+    }
+
+    /// The last wall-clock instant an alert sweep completed, if one has.
+    pub fn last_alert_check(&self) -> rusqlite::Result<Option<DateTime<Local>>> {
+        let Some(value) = self.setting(crate::notify::CHECKPOINT_SETTING_KEY)? else {
+            return Ok(None);
+        };
+        Ok(DateTime::parse_from_rfc3339(&value)
+            .ok()
+            .map(|timestamp| timestamp.with_timezone(&Local)))
+    }
+
+    pub fn set_last_alert_check(&self, when: DateTime<Local>) -> rusqlite::Result<()> {
+        self.set_setting(
+            crate::notify::CHECKPOINT_SETTING_KEY,
+            &stored_timestamp(&when),
+        )
     }
 
     pub fn local_calendars(&self) -> rusqlite::Result<Vec<Calendar>> {
@@ -716,6 +737,27 @@ impl Store {
         Ok(())
     }
 
+    /// Marks `id` as holding an unpushed local change. Sync upserts and prunes
+    /// skip the row until [`Self::clear_local_edit`].
+    pub fn mark_local_edit(&self, id: i64) -> rusqlite::Result<()> {
+        self.conn.execute(
+            "UPDATE events SET local_edit = 1 WHERE id = ?1",
+            params![id],
+        )?;
+        Ok(())
+    }
+
+    /// Clears the local-edit flag after a remote write succeeds, or after a
+    /// failed remote write has been rolled back, so a later sync may apply
+    /// server-side changes again.
+    pub fn clear_local_edit(&self, id: i64) -> rusqlite::Result<()> {
+        self.conn.execute(
+            "UPDATE events SET local_edit = 0 WHERE id = ?1",
+            params![id],
+        )?;
+        Ok(())
+    }
+
     pub fn update_event_attendees(&self, id: i64, attendees: &[Attendee]) -> rusqlite::Result<()> {
         self.conn.execute(
             "UPDATE events SET attendees = ?1 WHERE id = ?2",
@@ -734,11 +776,13 @@ impl Store {
     ///
     /// `reminder_minutes` is written on INSERT but deliberately left out of the
     /// `DO UPDATE`: an alert is Calix-local — nothing sends it to Google, and
-    /// nothing reads one back — so the row created right after the user adds an
-    /// event is the only chance to keep the alert they picked, while every later
-    /// sync must leave the column alone rather than blank it. (An alert on a
-    /// *recurring* remote event still can't outlive the first sync, which
-    /// replaces the series row with the provider's expanded instances.)
+    /// nothing reads one back — so a later sync must leave the column alone
+    /// rather than blank it. A newly expanded occurrence of a series copies
+    /// the reminder from `inherit_reminder_from` (the series id) so an alert
+    /// set at create time survives the first sync replacing the master row.
+    ///
+    /// Rows marked `local_edit` are not overwritten: an in-flight local change
+    /// waiting on a remote push must not lose to a concurrent pull.
     pub fn upsert_google_event(
         &self,
         calendar_id: i64,
@@ -746,30 +790,38 @@ impl Store {
         draft: &EventDraft,
         attendees: &[Attendee],
     ) -> rusqlite::Result<()> {
-        self.conn.execute(
-            "INSERT INTO events (calendar_id, title, start_at, end_at, all_day, location, notes, google_event_id, attendees, reminder_minutes)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
-             ON CONFLICT(calendar_id, google_event_id) WHERE google_event_id IS NOT NULL
-             DO UPDATE SET title = ?2, start_at = ?3, end_at = ?4, all_day = ?5, location = ?6, notes = ?7, attendees = ?9",
-            params![
-                calendar_id,
-                draft.title,
-                stored_timestamp(&draft.start),
-                stored_timestamp(&draft.end),
-                draft.all_day as i64,
-                draft.location,
-                draft.notes,
-                google_event_id,
-                attendees_to_json(attendees),
-                draft.reminder_minutes,
-            ],
-        )?;
-        Ok(())
+        self.upsert_synced_event(
+            calendar_id,
+            "google_event_id",
+            google_event_id,
+            None,
+            draft,
+            attendees,
+        )
+    }
+
+    pub fn upsert_google_event_from_series(
+        &self,
+        calendar_id: i64,
+        google_event_id: &str,
+        inherit_reminder_from: Option<&str>,
+        draft: &EventDraft,
+        attendees: &[Attendee],
+    ) -> rusqlite::Result<()> {
+        self.upsert_synced_event(
+            calendar_id,
+            "google_event_id",
+            google_event_id,
+            inherit_reminder_from,
+            draft,
+            attendees,
+        )
     }
 
     /// Creates or updates a CalDAV-sourced event by its href. Handles
-    /// `reminder_minutes` exactly as [`Self::upsert_google_event`] does, and for
-    /// the same reason.
+    /// `reminder_minutes` and `local_edit` exactly as
+    /// [`Self::upsert_google_event`] does. Expanded instances (`href#id`)
+    /// inherit the reminder stored on the bare href.
     pub fn upsert_caldav_event(
         &self,
         calendar_id: i64,
@@ -777,11 +829,47 @@ impl Store {
         draft: &EventDraft,
         attendees: &[Attendee],
     ) -> rusqlite::Result<()> {
+        self.upsert_synced_event(
+            calendar_id,
+            "icloud_event_id",
+            icloud_event_id,
+            icloud_event_id.split_once('#').map(|(href, _)| href),
+            draft,
+            attendees,
+        )
+    }
+
+    fn upsert_synced_event(
+        &self,
+        calendar_id: i64,
+        id_column: &str,
+        remote_id: &str,
+        inherit_reminder_from: Option<&str>,
+        draft: &EventDraft,
+        attendees: &[Attendee],
+    ) -> rusqlite::Result<()> {
+        debug_assert!(
+            id_column == "google_event_id" || id_column == "icloud_event_id",
+            "id_column is a trusted SQL identifier"
+        );
+        let inherit = inherit_reminder_from.unwrap_or(remote_id);
+        let sql = format!(
+            "INSERT INTO events (calendar_id, title, start_at, end_at, all_day, location, notes, {id_column}, attendees, reminder_minutes)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9,
+                COALESCE(
+                    (SELECT reminder_minutes FROM events
+                     WHERE calendar_id = ?1
+                       AND {id_column} = ?11
+                       AND reminder_minutes IS NOT NULL
+                     LIMIT 1),
+                    ?10
+                ))
+             ON CONFLICT(calendar_id, {id_column}) WHERE {id_column} IS NOT NULL
+             DO UPDATE SET title = ?2, start_at = ?3, end_at = ?4, all_day = ?5, location = ?6, notes = ?7, attendees = ?9
+             WHERE local_edit = 0"
+        );
         self.conn.execute(
-            "INSERT INTO events (calendar_id, title, start_at, end_at, all_day, location, notes, icloud_event_id, attendees, reminder_minutes)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
-             ON CONFLICT(calendar_id, icloud_event_id) WHERE icloud_event_id IS NOT NULL
-             DO UPDATE SET title = ?2, start_at = ?3, end_at = ?4, all_day = ?5, location = ?6, notes = ?7, attendees = ?9",
+            &sql,
             params![
                 calendar_id,
                 draft.title,
@@ -790,9 +878,10 @@ impl Store {
                 draft.all_day as i64,
                 draft.location,
                 draft.notes,
-                icloud_event_id,
+                remote_id,
                 attendees_to_json(attendees),
                 draft.reminder_minutes,
+                inherit,
             ],
         )?;
         Ok(())
@@ -812,7 +901,8 @@ impl Store {
             self.conn.execute(
                 "DELETE FROM events
                  WHERE calendar_id = ?1 AND google_event_id IS NOT NULL
-                   AND start_at < ?2 AND end_at > ?3",
+                   AND start_at < ?2 AND end_at > ?3
+                   AND local_edit = 0",
                 params![
                     calendar_id,
                     stored_timestamp(&range_end),
@@ -827,6 +917,7 @@ impl Store {
             "DELETE FROM events
              WHERE calendar_id = ? AND google_event_id IS NOT NULL
                AND start_at < ? AND end_at > ?
+               AND local_edit = 0
                AND google_event_id NOT IN ({placeholders})"
         );
         let range_end = stored_timestamp(&range_end);
@@ -855,7 +946,8 @@ impl Store {
         let mut sql = String::from(
             "DELETE FROM events
              WHERE calendar_id = ? AND icloud_event_id IS NOT NULL
-               AND start_at < ? AND end_at > ?",
+               AND start_at < ? AND end_at > ?
+               AND local_edit = 0",
         );
         let range_end = stored_timestamp(&range_end);
         let range_start = stored_timestamp(&range_start);
@@ -2207,6 +2299,237 @@ mod tests {
             .unwrap();
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].reminder_minutes, Some(5));
+    }
+
+    #[test]
+    fn last_alert_check_round_trips_through_settings() {
+        let store = Store::open_in_memory().unwrap();
+        assert!(store.last_alert_check().unwrap().is_none());
+        let when = Local
+            .with_ymd_and_hms(2026, 8, 21, 9, 0, 0)
+            .single()
+            .unwrap();
+        store.set_last_alert_check(when).unwrap();
+        let stored = store.last_alert_check().unwrap().unwrap();
+        assert_eq!(stored.timestamp(), when.timestamp());
+    }
+
+    #[test]
+    fn a_sync_upsert_does_not_clobber_an_unpushed_local_edit() {
+        let store = Store::open_in_memory().unwrap();
+        let account_id = store
+            .upsert_google_account(
+                "person@example.com",
+                "person@example.com",
+                "google-refresh-token:person@example.com",
+            )
+            .unwrap();
+        let calendar_id = store
+            .upsert_google_calendar(account_id, "cal-abc", "Work", "#ff0000", true)
+            .unwrap();
+        let start = Local
+            .with_ymd_and_hms(2026, 7, 20, 12, 0, 0)
+            .single()
+            .unwrap();
+        let end = start + Duration::hours(1);
+        store
+            .upsert_google_event(calendar_id, "evt-1", &draft("Lunch", start, end), &[])
+            .unwrap();
+        let id = store
+            .events_between(start - Duration::hours(1), end)
+            .unwrap()[0]
+            .id;
+        let moved = start + Duration::hours(1);
+        store
+            .update_event(id, &draft("Lunch", moved, moved + Duration::hours(1)))
+            .unwrap();
+        store.mark_local_edit(id).unwrap();
+
+        store
+            .upsert_google_event(
+                calendar_id,
+                "evt-1",
+                &draft("Lunch (from server)", start, end),
+                &[],
+            )
+            .unwrap();
+
+        let events = store
+            .events_between(start - Duration::hours(1), moved + Duration::hours(2))
+            .unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].title, "Lunch");
+        assert_eq!(events[0].start, moved);
+
+        store.clear_local_edit(id).unwrap();
+        store
+            .upsert_google_event(
+                calendar_id,
+                "evt-1",
+                &draft("Lunch (from server)", start, end),
+                &[],
+            )
+            .unwrap();
+        let events = store
+            .events_between(start - Duration::hours(1), end + Duration::hours(1))
+            .unwrap();
+        assert_eq!(events[0].title, "Lunch (from server)");
+        assert_eq!(events[0].start, start);
+    }
+
+    #[test]
+    fn prune_preserves_an_unpushed_local_edit() {
+        let store = Store::open_in_memory().unwrap();
+        let account_id = store
+            .upsert_google_account(
+                "person@example.com",
+                "person@example.com",
+                "google-refresh-token:person@example.com",
+            )
+            .unwrap();
+        let calendar_id = store
+            .upsert_google_calendar(account_id, "cal-abc", "Work", "#ff0000", true)
+            .unwrap();
+        let start = Local
+            .with_ymd_and_hms(2026, 7, 20, 12, 0, 0)
+            .single()
+            .unwrap();
+        let end = start + Duration::hours(1);
+        store
+            .upsert_google_event(calendar_id, "evt-1", &draft("Lunch", start, end), &[])
+            .unwrap();
+        let id = store
+            .events_between(start - Duration::hours(1), end)
+            .unwrap()[0]
+            .id;
+        store.mark_local_edit(id).unwrap();
+        store
+            .prune_google_events(
+                calendar_id,
+                &["other".to_string()],
+                start - Duration::hours(1),
+                end + Duration::hours(1),
+            )
+            .unwrap();
+        let events = store
+            .events_between(start - Duration::hours(1), end)
+            .unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].title, "Lunch");
+    }
+
+    #[test]
+    fn expanded_caldav_instances_inherit_the_masters_reminder() {
+        let store = Store::open_in_memory().unwrap();
+        let account_id = store
+            .upsert_icloud_account(
+                "person@example.com",
+                "person@example.com",
+                "icloud-app-password:person@example.com",
+            )
+            .unwrap();
+        let calendar_id = store
+            .upsert_caldav_calendar(account_id, "/calendars/work/", "Work", "#ff9500", true)
+            .unwrap();
+        let start = Local
+            .with_ymd_and_hms(2026, 7, 20, 9, 0, 0)
+            .single()
+            .unwrap();
+        let end = start + Duration::hours(1);
+        let mut with_alert = draft("Standup", start, end);
+        with_alert.reminder_minutes = Some(10);
+        store
+            .upsert_caldav_event(calendar_id, "/calendars/work/standup.ics", &with_alert, &[])
+            .unwrap();
+
+        let occurrence = start + Duration::days(7);
+        store
+            .upsert_caldav_event(
+                calendar_id,
+                "/calendars/work/standup.ics#20260727T090000Z",
+                &draft("Standup", occurrence, occurrence + Duration::hours(1)),
+                &[],
+            )
+            .unwrap();
+        store
+            .prune_caldav_events(
+                calendar_id,
+                &["/calendars/work/standup.ics#20260727T090000Z".to_string()],
+                &[],
+                start - Duration::hours(1),
+                occurrence + Duration::hours(2),
+            )
+            .unwrap();
+
+        let events = store
+            .events_between(
+                occurrence - Duration::hours(1),
+                occurrence + Duration::hours(2),
+            )
+            .unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].reminder_minutes, Some(10));
+        assert_eq!(
+            events[0].icloud_event_id.as_deref(),
+            Some("/calendars/work/standup.ics#20260727T090000Z")
+        );
+    }
+
+    #[test]
+    fn expanded_google_instances_inherit_the_series_reminder() {
+        let store = Store::open_in_memory().unwrap();
+        let account_id = store
+            .upsert_google_account(
+                "person@example.com",
+                "person@example.com",
+                "google-refresh-token:person@example.com",
+            )
+            .unwrap();
+        let calendar_id = store
+            .upsert_google_calendar(account_id, "cal-abc", "Work", "#ff0000", true)
+            .unwrap();
+        let start = Local
+            .with_ymd_and_hms(2026, 7, 20, 9, 0, 0)
+            .single()
+            .unwrap();
+        let end = start + Duration::hours(1);
+        let mut with_alert = draft("Standup", start, end);
+        with_alert.reminder_minutes = Some(15);
+        store
+            .upsert_google_event(calendar_id, "series-1", &with_alert, &[])
+            .unwrap();
+
+        let occurrence = start + Duration::days(7);
+        store
+            .upsert_google_event_from_series(
+                calendar_id,
+                "series-1_20260727T130000Z",
+                Some("series-1"),
+                &draft("Standup", occurrence, occurrence + Duration::hours(1)),
+                &[],
+            )
+            .unwrap();
+        store
+            .prune_google_events(
+                calendar_id,
+                &["series-1_20260727T130000Z".to_string()],
+                start - Duration::hours(1),
+                occurrence + Duration::hours(2),
+            )
+            .unwrap();
+
+        let events = store
+            .events_between(
+                occurrence - Duration::hours(1),
+                occurrence + Duration::hours(2),
+            )
+            .unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].reminder_minutes, Some(15));
+        assert_eq!(
+            events[0].google_event_id.as_deref(),
+            Some("series-1_20260727T130000Z")
+        );
     }
 
     #[test]

--- a/src/views/mod.rs
+++ b/src/views/mod.rs
@@ -108,3 +108,88 @@ fn show_new_event_menu(
     });
     popover.popup();
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::Event;
+    use chrono::{Duration, TimeZone};
+
+    fn event_on(
+        start: chrono::DateTime<Local>,
+        end: chrono::DateTime<Local>,
+        all_day: bool,
+    ) -> Event {
+        Event {
+            id: 1,
+            calendar_id: 1,
+            calendar_name: "Local".into(),
+            calendar_color: "#3584e4".into(),
+            account_provider: None,
+            account_provider_id: None,
+            account_token_key: None,
+            google_calendar_id: None,
+            title: "Event".into(),
+            start,
+            end,
+            all_day,
+            location: None,
+            notes: None,
+            google_event_id: None,
+            icloud_event_id: None,
+            account_server_url: None,
+            attendees: Vec::new(),
+            recurrence: None,
+            reminder_minutes: None,
+        }
+    }
+
+    fn at(y: i32, m: u32, d: u32) -> chrono::DateTime<Local> {
+        Local.with_ymd_and_hms(y, m, d, 0, 0, 0).unwrap()
+    }
+
+    #[test]
+    fn a_timed_event_occurs_on_its_start_day() {
+        let start = Local.with_ymd_and_hms(2026, 8, 21, 9, 0, 0).unwrap();
+        let event = event_on(start, start + Duration::hours(1), false);
+        assert!(event_occurs_on_day(
+            &event,
+            NaiveDate::from_ymd_opt(2026, 8, 21).unwrap()
+        ));
+        assert!(!event_occurs_on_day(
+            &event,
+            NaiveDate::from_ymd_opt(2026, 8, 22).unwrap()
+        ));
+    }
+
+    #[test]
+    fn an_all_day_event_does_not_include_its_exclusive_end_date() {
+        // All-day on the 21st is stored as [21st 00:00, 22nd 00:00).
+        let event = event_on(at(2026, 8, 21), at(2026, 8, 22), true);
+        assert!(event_occurs_on_day(
+            &event,
+            NaiveDate::from_ymd_opt(2026, 8, 21).unwrap()
+        ));
+        assert!(!event_occurs_on_day(
+            &event,
+            NaiveDate::from_ymd_opt(2026, 8, 22).unwrap()
+        ));
+    }
+
+    #[test]
+    fn a_multi_day_all_day_event_covers_each_inclusive_day() {
+        let event = event_on(at(2026, 8, 21), at(2026, 8, 24), true);
+        assert!(event_occurs_on_day(
+            &event,
+            NaiveDate::from_ymd_opt(2026, 8, 21).unwrap()
+        ));
+        assert!(event_occurs_on_day(
+            &event,
+            NaiveDate::from_ymd_opt(2026, 8, 23).unwrap()
+        ));
+        assert!(!event_occurs_on_day(
+            &event,
+            NaiveDate::from_ymd_opt(2026, 8, 24).unwrap()
+        ));
+    }
+}

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,3 +1,4 @@
+use crate::autostart;
 use crate::caldav;
 use crate::calendar_dialog;
 use crate::config::Config;
@@ -999,10 +1000,43 @@ impl Ui {
 }
 
 thread_local! {
-    /// The window that's up, so a forwarded `calix <date>` can move it. Only
-    /// ever read back through `open`, which drops it if the window it belongs
-    /// to has since gone.
+    /// The window that's up, so a forwarded `calix <date>` can move it.
+    /// One `Ui` per process: `open` reuses this instead of building a second
+    /// set of timers when the window was only hidden.
     static LIVE_UI: RefCell<Option<Rc<Ui>>> = const { RefCell::new(None) };
+    /// The logind resume subscription is process-wide; a second `build`
+    /// must not `mem::forget` another one.
+    static LOGIND_SUBSCRIBED: Cell<bool> = const { Cell::new(false) };
+    /// Set when this process started as the background alert process, so
+    /// closing the window hides it rather than destroying the session.
+    static BACKGROUND_SESSION: Cell<bool> = const { Cell::new(false) };
+}
+
+/// Whether this process already has a `Ui` and should reuse it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SessionAction {
+    Reuse,
+    Build,
+}
+
+fn session_action(live_exists: bool) -> SessionAction {
+    if live_exists {
+        SessionAction::Reuse
+    } else {
+        SessionAction::Build
+    }
+}
+
+fn hide_window_instead_of_destroying(keep_running: bool) -> bool {
+    keep_running
+}
+
+fn should_subscribe_to_logind(already_subscribed: bool) -> bool {
+    !already_subscribed
+}
+
+fn session_keeps_running() -> bool {
+    BACKGROUND_SESSION.with(Cell::get) || autostart::enabled()
 }
 
 /// Shows Calix on `date`, or wherever it already was when no date was asked
@@ -1010,25 +1044,24 @@ thread_local! {
 /// `calix` invocation moves the one on screen instead of opening another.
 pub fn open(app: &adw::Application, date: Option<NaiveDate>) {
     let live = LIVE_UI.with(|live| live.borrow().clone());
-    match live.filter(|_| app.active_window().is_some()) {
-        Some(ui) => {
+    match session_action(live.is_some()) {
+        SessionAction::Reuse => {
+            let ui = live.expect("Reuse requires a live session");
             if let Some(date) = date {
                 ui.state.borrow_mut().current_date = date;
                 ui.reset();
             }
-            if let Some(window) = app.active_window() {
+            if let Some(window) = app.windows().into_iter().next() {
                 window.present();
             }
         }
-        None => {
-            LIVE_UI.with(|live| live.replace(None));
-            build(app, date, true);
-        }
+        SessionAction::Build => build(app, date, true),
     }
 }
 
 pub fn start_background(app: &adw::Application) {
-    if LIVE_UI.with(|live| live.borrow().is_none()) {
+    BACKGROUND_SESSION.with(|flag| flag.set(true));
+    if session_action(LIVE_UI.with(|live| live.borrow().is_some())) == SessionAction::Build {
         build(app, None, false);
     }
 }
@@ -1102,7 +1135,7 @@ fn build(app: &adw::Application, date: Option<NaiveDate>, show_window: bool) {
     // reasonably fresh while the app is awake. This timer is frozen during
     // suspend (GLib's monotonic clock stops), so recovery from an overnight
     // sleep comes from the logind resume listener below, not from this tick.
-    glib::timeout_add_seconds_local(
+    let clock_source = Cell::new(Some(glib::timeout_add_seconds_local(
         30,
         clone!(
             #[weak]
@@ -1114,7 +1147,7 @@ fn build(app: &adw::Application, date: Option<NaiveDate>, show_window: bool) {
                 glib::ControlFlow::Continue
             }
         ),
-    );
+    )));
 
     // Surface event alerts as desktop notifications. Each tick checks the
     // window since the previous one — contiguous half-open windows, so an
@@ -1122,8 +1155,8 @@ fn build(app: &adw::Application, date: Option<NaiveDate>, show_window: bool) {
     // then fires late rather than silently dropping). The two-day query
     // horizon comfortably covers the longest lead time, one day.
     let notify_app = app.clone();
-    let last_alert_check = Cell::new(Local::now());
-    glib::timeout_add_seconds_local(
+    sweep_due_alerts(&ui, &notify_app);
+    let alert_source = Cell::new(Some(glib::timeout_add_seconds_local(
         60,
         clone!(
             #[weak]
@@ -1131,29 +1164,11 @@ fn build(app: &adw::Application, date: Option<NaiveDate>, show_window: bool) {
             #[upgrade_or]
             glib::ControlFlow::Break,
             move || {
-                let now = Local::now();
-                let since = last_alert_check.replace(now);
-                let Ok(events) = ui
-                    .store
-                    .events_between(since, now + ChronoDuration::days(2))
-                else {
-                    return glib::ControlFlow::Continue;
-                };
-                for event in crate::notify::due_alerts(&events, since, now) {
-                    let notification = gio::Notification::new(&event.title);
-                    notification.set_body(Some(&crate::notify::notification_body(&event, now)));
-                    // Id'd by occurrence so a repeated send replaces instead
-                    // of stacking, and each occurrence of a series alerts
-                    // separately.
-                    notify_app.send_notification(
-                        Some(&format!("event-{}-{}", event.id, event.start.timestamp())),
-                        &notification,
-                    );
-                }
+                sweep_due_alerts(&ui, &notify_app);
                 glib::ControlFlow::Continue
             }
         ),
-    );
+    )));
 
     // Tooltips carry the accelerator: with no menu bar and no shortcuts
     // window yet, the control itself is the only place a binding can be
@@ -1313,15 +1328,15 @@ fn build(app: &adw::Application, date: Option<NaiveDate>, show_window: bool) {
     // don't nag; `sync_connected_accounts` touches only providers that have an
     // account and aren't already mid-sync. The launch pass is deferred a beat
     // so the window paints first.
-    glib::timeout_add_local_once(
+    let launch_sync = Cell::new(Some(glib::timeout_add_local_once(
         Duration::from_millis(100),
         clone!(
             #[strong]
             ui,
             move || sync_connected_accounts(&ui)
         ),
-    );
-    glib::timeout_add_seconds_local(
+    )));
+    let periodic_sync = Cell::new(Some(glib::timeout_add_seconds_local(
         15 * 60,
         clone!(
             #[weak]
@@ -1333,7 +1348,7 @@ fn build(app: &adw::Application, date: Option<NaiveDate>, show_window: bool) {
                 glib::ControlFlow::Continue
             }
         ),
-    );
+    )));
 
     // The periodic timers above run on GLib's monotonic clock, which is frozen
     // while the machine is suspended — so after an overnight sleep they don't
@@ -1345,17 +1360,17 @@ fn build(app: &adw::Application, date: Option<NaiveDate>, show_window: bool) {
     // a background sync. gio speaks D-Bus, so this needs no new dependency; the
     // shared system-bus connection is kept alive by gio for the process's life,
     // which keeps the subscription live.
-    if let Ok(system_bus) = gio::bus_get_sync(gio::BusType::System, gio::Cancellable::NONE) {
-        let subscription = system_bus.subscribe_to_signal(
-            Some("org.freedesktop.login1"),
-            Some("org.freedesktop.login1.Manager"),
-            Some("PrepareForSleep"),
-            Some("/org/freedesktop/login1"),
-            None,
-            gio::DBusSignalFlags::NONE,
-            clone!(
-                #[weak]
-                ui,
+    if should_subscribe_to_logind(LOGIND_SUBSCRIBED.with(Cell::get)) {
+        LOGIND_SUBSCRIBED.with(|flag| flag.set(true));
+        if let Ok(system_bus) = gio::bus_get_sync(gio::BusType::System, gio::Cancellable::NONE) {
+            let resume_app = app.clone();
+            let subscription = system_bus.subscribe_to_signal(
+                Some("org.freedesktop.login1"),
+                Some("org.freedesktop.login1.Manager"),
+                Some("PrepareForSleep"),
+                Some("/org/freedesktop/login1"),
+                None,
+                gio::DBusSignalFlags::NONE,
                 move |signal| {
                     // PrepareForSleep(b): `true` just before sleep, `false`
                     // right after resume. Only the resume edge matters; treat an
@@ -1369,14 +1384,18 @@ fn build(app: &adw::Application, date: Option<NaiveDate>, show_window: bool) {
                     {
                         return;
                     }
+                    let Some(ui) = LIVE_UI.with(|live| live.borrow().clone()) else {
+                        return;
+                    };
                     ui.tick_clock();
                     sync_connected_accounts(&ui);
-                }
-            ),
-        );
-        // The subscription unsubscribes when dropped; there is exactly one, for
-        // the whole process, so leak it to keep the resume listener alive.
-        std::mem::forget(subscription);
+                    sweep_due_alerts(&ui, &resume_app);
+                },
+            );
+            // The subscription unsubscribes when dropped. Installed once per
+            // process and leaked so a later rebuild cannot stack another.
+            std::mem::forget(subscription);
+        }
     }
 
     let calendars_button = gtk::ToggleButton::new();
@@ -1422,6 +1441,30 @@ fn build(app: &adw::Application, date: Option<NaiveDate>, show_window: bool) {
         .default_height(750)
         .content(&ui.toast_overlay)
         .build();
+
+    window.connect_close_request(|window| {
+        if hide_window_instead_of_destroying(session_keeps_running()) {
+            window.set_visible(false);
+            glib::Propagation::Stop
+        } else {
+            glib::Propagation::Proceed
+        }
+    });
+    window.connect_destroy(move |_| {
+        LIVE_UI.with(|live| live.replace(None));
+        if let Some(id) = clock_source.take() {
+            id.remove();
+        }
+        if let Some(id) = alert_source.take() {
+            id.remove();
+        }
+        if let Some(id) = launch_sync.take() {
+            id.remove();
+        }
+        if let Some(id) = periodic_sync.take() {
+            id.remove();
+        }
+    });
 
     // Each command re-triggers the control that already performs it rather
     // than repeating its body, so a shortcut can't drift from the button it
@@ -1612,6 +1655,32 @@ fn build(app: &adw::Application, date: Option<NaiveDate>, show_window: bool) {
             glib::ControlFlow::Break
         }
     ));
+}
+
+fn sweep_due_alerts(ui: &Ui, app: &impl IsA<gio::Application>) {
+    let now = Local::now();
+    let stored = ui.store.last_alert_check().ok().flatten();
+    let since = crate::notify::alert_window(stored, now);
+    let Ok(events) = ui
+        .store
+        .events_between(since, now + ChronoDuration::days(2))
+    else {
+        return;
+    };
+    for event in crate::notify::due_alerts(&events, since, now) {
+        let notification = gio::Notification::new(&event.title);
+        notification.set_body(Some(&crate::notify::notification_body(&event, now)));
+        // Id'd by occurrence so a repeated send replaces instead
+        // of stacking, and each occurrence of a series alerts
+        // separately.
+        app.send_notification(
+            Some(&format!("event-{}-{}", event.id, event.start.timestamp())),
+            &notification,
+        );
+    }
+    let _ = ui
+        .store
+        .set_last_alert_check(crate::notify::next_checkpoint(true, since, now));
 }
 
 fn sidebar_actions(
@@ -2024,6 +2093,7 @@ fn move_handler(
                     )));
                     return;
                 }
+                let _ = ui.store.mark_local_edit(event.id);
                 ui.reset();
 
                 let (tx, rx) = mpsc::channel();
@@ -2037,7 +2107,10 @@ fn move_handler(
                         #[strong]
                         ui,
                         move || match rx.try_recv() {
-                            Ok(Ok(())) => glib::ControlFlow::Break,
+                            Ok(Ok(())) => {
+                                let _ = ui.store.clear_local_edit(event.id);
+                                glib::ControlFlow::Break
+                            }
                             Ok(Err(error)) => {
                                 undo_failed_drag(&ui, event.id, &draft, &original);
                                 ui.toast_overlay.add_toast(adw::Toast::new(&format!(
@@ -2078,6 +2151,7 @@ fn undo_failed_drag(ui: &Rc<Ui>, event_id: i64, optimistic: &EventDraft, origina
         return;
     };
     if ui.store.update_event(event_id, &undo).is_ok() {
+        let _ = ui.store.clear_local_edit(event_id);
         ui.reset();
     }
 }
@@ -3874,6 +3948,25 @@ mod tests {
         activity.finish_sign_in();
         assert!(activity.start_sign_in());
     }
+
+    #[test]
+    fn a_live_session_is_reused_instead_of_starting_a_second_alert_loop() {
+        assert_eq!(session_action(true), SessionAction::Reuse);
+        assert_eq!(session_action(false), SessionAction::Build);
+    }
+
+    #[test]
+    fn the_window_hides_on_close_only_when_the_process_must_keep_running() {
+        assert!(hide_window_instead_of_destroying(true));
+        assert!(!hide_window_instead_of_destroying(false));
+    }
+
+    #[test]
+    fn logind_is_subscribed_once_per_process() {
+        assert!(should_subscribe_to_logind(false));
+        assert!(!should_subscribe_to_logind(true));
+    }
+
     use chrono::TimeZone;
 
     const CTRL: gdk::ModifierType = gdk::ModifierType::CONTROL_MASK;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Nine review follow-ups from Ian’s assigned list, against 0.6.0 (`1192785`). No 15-vs-30 drag-snap change. No undo/redo.

1. **One Ui per process.** `open()` reuses `LIVE_UI` instead of replacing it and calling `build()` again. Close hides the window while autostart/`hold()` keeps the process alive; destroy cancels the clock/alert/sync sources. Logind `PrepareForSleep` is subscribed once. `--background` no longer keys off `active_window()`, so a hidden session is not presented or rebuilt. Tests cover reuse vs build, hide-on-close, one logind subscribe, and background vs present. Full hide/present timer identity still needs a display.

2. **Persist last alert check.** `last_alert_check` is stored in settings. Startup/resume look back at most 36 hours. `next_checkpoint` keeps the previous value when `events_between` fails, so that window is retried.

3. **Google RSVP `sendUpdates=all`.** RSVP PATCHes go through `event_url_notifying`. CalDAV still PUTs `PARTSTAT` on the attendee’s copy; it does not POST an iTIP `METHOD:REPLY` (documented on `respond_to_event` and in the README). Many servers, including iCloud, treat that as a local status change only.

4. **Dirty flag on unpushed local edits.** `events.local_edit` skips sync upserts (`ON CONFLICT … WHERE local_edit = 0`) and prunes. Drag marks the row until the remote write succeeds or the optimistic move is undone.

5. **Filter CalDAV `STATUS:CANCELLED`.** Cancelled VEVENTs are dropped and count as a successful parse, so they do not protect the resource from prune. Fixture covers uppercase and lowercase `STATUS`.

6. **Calendar visibility switch.** `state-set` returns `Stop` when `set_calendar_visible` fails, so GTK does not flip the switch off the stored value.

7. **Reminders on expanded instances.** CalDAV `href#instance` rows inherit `reminder_minutes` from the bare href. Google expanded instances inherit from `recurringEventId`. Tests cover both after the master is pruned.

8. **README OAuth scopes** match `src/google/oauth.rs`: `calendar.events` and `calendar.calendarlist.readonly`, not `calendar`.

9. **Tests** for `event_occurs_on_day` (timed start day, all-day exclusive end, multi-day inclusive range) and the extracted single-alert-loop invariant (`session_action`: reuse live Ui, do not build a second loop).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-47b728d0-b46b-4d7e-b962-ac1a35742671?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47b728d0-b46b-4d7e-b962-ac1a35742671&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

